### PR TITLE
Fixed for Coq 8.14.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+.lia.cache
+_CoqProject
+Makefile.coq
+Makefile.coq.conf
+.Makefile.coq.d
 \#*\#
 *.log
 *~
@@ -5,3 +10,5 @@
 *.out
 *.glob
 *.vo
+*.vok
+*.vos

--- a/ARTIFACT.md
+++ b/ARTIFACT.md
@@ -1,8 +1,54 @@
-This code contains Coq proofs supplementing the _Making Weak Memory Models Fair_ paper.
-More on the artifact constructed from the code (including a VM image and installation guidelines) are stated in [ARTIFACT.md](ARTIFACT.md).
+This artifact provides the supplementary Coq development for the _Making Weak Memory Models Fair_ paper.
 
-### Project dependencies
-* [Coq 8.14.1](https://coq.inria.fr)
+
+# Getting Started
+
+The easiest way to check proofs is to use the prepared virtual machine.
+
+1. Install VirtualBox (we tested the process with version 6.1) with Oracle VM VirtualBox Extension pack.
+2. Open VirtualBox and navigate to ``File/Import Appliance``. Provide the path to the ``artifact.ova`` file from the downloaded artifact and follow instructions to create a VM.
+3. Run the newly created VM. 
+	- If a "RawFile#0 failed to create the raw output file ..." error occurs, try disabling serial ports in VirtualBox (`right click on VM -> Settings -> Serial Ports -> uncheck "Enable Serial Port" boxes`). See [the discussion](https://github.com/joelhandwell/ubuntu_vagrant_boxes/issues/1) of the related problem.
+4. Login with username and password "vagrant".
+5. Navigate to ``/home/vagrant/artifact_compiled`` in a terminal and run ``make -j 4``. Since proofs are pre-compiled, it should terminate in a second. You may also run ``make clean; make -j 4`` to recompile proofs from scratch (adjust the `-j` parameter according to the number of available cores). 
+6. Run ``grep -HRi admit`` to ensure there are no incomplete proofs.
+7. Check that Coq formalization matches the paper's claims (see the correspondence below).
+8. The VM includes configured Emacs w/ Proof General and Vim w/ Coqtail so you can edit proofs interactively. 
+
+# Step-by-step Instructions
+
+## Reproducing the environment
+
+Besides running the prepared virtual machine, you can reproduce the environment either automatically or manually. 
+
+### Creating a Vagrant box 
+
+Our VM is created using the Vagrant tool, which simplifies virtual machines management. You can reproduce our environment with the configuration we provide.
+
+1. [Install Vagrant](https://www.vagrantup.com/) (we tested the process with version 2.2.16).
+2. Unpack the `artifact.zip` archive somewhere; we'll refer to the resulting folder's path as `artifact/`. 
+3. Copy the `artifact.zip` archive into the `artifact/vagrant` folder. This will allow to copy the artifact code into the VM during the build.
+3. (Optionally) Change the desired amount of RAM that will be dedicated to the VM 
+by changing  the ``v.memory`` parameter in the ``artifact/vagrant/Vagrantfile`` file in the downloaded artifact.
+4. In a terminal, navigate to the ``artifact/vagrant/`` folder and run ``vagrant up``. It will download the base OS image, create a clean VM, install all needed dependencies and editing tools, and import proofs sources into the VM. It may take about an hour to complete. 
+5. After the installation completion, run ``vagrant reload`` to restart the VM with the graphical environment.
+   - If the machine doesn't boot, see the "Getting Started" section for possible workarounds. 
+6. Vagrant build creates `~/artifact` and `~/artifact_compiled` folders and runs `make` in the latter so to edit proofs it's easier to access files in `~/artifact_compiled`. 
+
+### Manual installation
+
+You can reproduce the environment by hand. Any system capable of running `opam` should be appropriate. Note that, depending on your system, it may require additional steps not covered here (especially if you don't have ``opam`` installed already). 
+
+1. [Install ``opam``](https://opam.ocaml.org/doc/Install.html) (we tested the process with version ``2.1.0``). 
+2. Perform ``opam`` initialization: ``opam init -a``. The ``-a`` key makes adjustments in your ``~/.profile`` to ease the ``opam`` usage, so we recommend keeping it. 
+3. Create a new ``opam`` environment, switch to it and update the current shell: ``opam switch create artifact 4.12.0; opam switch set artifact; eval $(opam env)``. Note that creating an environment may take about 20 minutes. Also, note that this step is omitted in Vagrant build, but we strongly recommend performing it in manual installation to isolate the artifact environment. 
+4. Install project dependencies. In a terminal, navigate to the top-level ``artifact/`` folder and run ``configure``. This will add an additional repository to the current ``opam`` environment and install the required dependencies. Note that it may take about 20 minutes. The exact versions of dependencies are specified in ``configure`` file but their latest versions should work as well. 
+5. By that moment you may run ``make`` to compile proofs. 
+6. To edit proofs you can use any appropriate tool available on your system. 
+   - If you choose Emacs note that some characters are missing in the default Emacs font. On Debian-based distributives it can be fixed by installing the ``ttf-ancient-fonts`` package; on other distributives, there should be similar packages. Otherwise, Proof General with ``company-coq`` installed should display everything fine. 
+
+### Project dependencies (already installed in the VM image)
+* [Coq 8.13.2](https://coq.inria.fr)
 * [Hahn library](https://github.com/vafeiadis/hahn) (`coq-hahn`). This library provides useful definitions and proofs of various relations and sets properties, as well as a general trace definition used throughout the development.
 
 ## List of paper claims and definitions supported by the artifact

--- a/src/basic/Execution.v
+++ b/src/basic/Execution.v
@@ -830,10 +830,10 @@ Proof using.
   { rewrite SUBco, wf_col0; clear; basic_solver. }
   { by rewrite SUBco, <- restr_relE; apply transitive_restr. }
   { revert wf_co_total0; rewrite SUBco; unfolder.
-    ins; desf; eapply H in NEQ; eauto; desf; eauto. }
+    ins; desf. eapply wf_co_total0 in NEQ; eauto; desf; eauto. }
   { rewrite SUBco; basic_solver. }
-  { rewrite SUBco, !seqA, seq_eqvC;
-      seq_rewrite wf_co_init0; basic_solver. }
+  rewrite SUBco, !seqA, seq_eqvC;
+    seq_rewrite wf_co_init0; basic_solver.
 Qed.
 
 Lemma sub_execution_trans G G' G'' :

--- a/src/equivalence/tso/TSO_decl_op.v
+++ b/src/equivalence/tso/TSO_decl_op.v
@@ -1075,15 +1075,16 @@ Proof.
        { apply NoDup_Permutation.
          1, 2: by (eapply Permutation_NoDup; eauto). 
          ins. eapply iff_trans. 
-         { symmetry. generalize x. apply set_equiv_exp_iff. apply sb_sort_sim. }
+         { symmetry. generalize x.
+           apply set_equiv_exp_iff. apply sb_sort_sim. }
          symmetry. eapply iff_trans.
-         { symmetry. generalize x. apply set_equiv_exp_iff. apply sb_sort_sim. }
-         generalize x. apply set_equiv_exp_iff, H. }
+         { symmetry. generalize x.
+           apply set_equiv_exp_iff. apply sb_sort_sim. }
+         generalize x. now apply set_equiv_exp_iff. }
        { apply sort_ninit with (thread := thread); auto. 
-         { rewrite <- H, <- L0, CE_E. basic_solver. }
-         { rewrite <- H, <- L0. basic_solver. } }
-       { auto. }
-  }
+         { rewrite <- L'0, <- L0, CE_E. basic_solver. }
+         rewrite <- L'0, <- L0. basic_solver. }
+       auto. }
   
   assert (StronglySorted ext_sb (sb_sort l ++ Bf_events i)) as SORTED_APP. 
   { apply StronglySorted_app.
@@ -3063,7 +3064,7 @@ Proof.
     unfold cur_events, covered_events. rewrite seq0. simpl.
     arewrite (⦗fun _ : Event => False⦘ ≡ ∅₂) by basic_solver.
     rewrite !seq_false_r, dom_empty, set_inter_empty_l.
-    destruct x; auto. ins. exfalso. apply (proj2 H0 e). auto. }
+    destruct x; auto. ins. exfalso. apply (proj2 a0 e). auto. }
   destruct (classic (NOmega.le (NOnum (S i)) (set_size (E \₁ is_init)))) as [DOM| ].
   2: { exists TSO.Minit. done. }
   red in IHi. specialize_full IHi; [liaW (set_size (E \₁ is_init))| ].


### PR DESCRIPTION
Fixed to compile w/ Coq 8.14.1. There were a couple of minor problems related to changed name assigning scheme.
Also, moved VM and installation related sections from `README.md` to `ARTIFACT.md` since they refer to Coq 8.13.

@fresheed please check that you agree w/ the changes.